### PR TITLE
Allow user to override file extension when loading data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # dply changelog
 Changes to the `dply` crate are documented in this file.
 
+## 0.2.1 - Unreleased
+### 🐛 Fixed
+* Allow user to override file extensions when loading data.
+
 ## 0.2.0 - 2023-08-14
 ### 🔧 Changed
 * Use DataFusion as query engine.

--- a/src/engine/csv.rs
+++ b/src/engine/csv.rs
@@ -55,15 +55,23 @@ pub fn eval(args: &[Expr], ctx: &mut Context) -> Result<()> {
         }
     } else {
         // Read the data frame and set it as input for the next task.
-        let table_path = ListingTableUrl::parse(path)?;
+        let table_path = ListingTableUrl::parse(&path)?;
 
         let num_cpus = std::thread::available_parallelism()
             .unwrap_or(NonZeroUsize::new(2).unwrap())
             .get();
 
         let file_format = CsvFormat::default();
+
+        // Use default extension for recursive loading.
+        let extension = if Path::new(&path).is_dir() {
+            DEFAULT_CSV_EXTENSION
+        } else {
+            ""
+        };
+
         let listing_options = ListingOptions::new(Arc::new(file_format))
-            .with_file_extension(DEFAULT_CSV_EXTENSION)
+            .with_file_extension(extension)
             .with_target_partitions(num_cpus);
 
         let resolved_schema =

--- a/src/engine/json.rs
+++ b/src/engine/json.rs
@@ -55,7 +55,7 @@ pub fn eval(args: &[Expr], ctx: &mut Context) -> Result<()> {
         }
     } else {
         // Read the data frame and set it as input for the next task.
-        let table_path = ListingTableUrl::parse(path)?;
+        let table_path = ListingTableUrl::parse(&path)?;
 
         let num_cpus = std::thread::available_parallelism()
             .unwrap_or(NonZeroUsize::new(2).unwrap())
@@ -65,8 +65,15 @@ pub fn eval(args: &[Expr], ctx: &mut Context) -> Result<()> {
 
         let file_format = JsonFormat::default().with_schema_infer_max_rec(schema_infer_rows);
 
+        // Use default extension for recursive loading.
+        let extension = if Path::new(&path).is_dir() {
+            DEFAULT_JSON_EXTENSION
+        } else {
+            ""
+        };
+
         let listing_options = ListingOptions::new(Arc::new(file_format))
-            .with_file_extension(DEFAULT_JSON_EXTENSION)
+            .with_file_extension(extension)
             .with_target_partitions(num_cpus);
 
         let resolved_schema =

--- a/src/engine/parquet.rs
+++ b/src/engine/parquet.rs
@@ -64,15 +64,22 @@ pub fn eval(args: &[Expr], ctx: &mut Context) -> Result<()> {
         writer.close()?;
     } else {
         // Read the data frame and set it as input for the next task.
-        let table_path = ListingTableUrl::parse(path)?;
+        let table_path = ListingTableUrl::parse(&path)?;
 
         let num_cpus = std::thread::available_parallelism()
             .unwrap_or(NonZeroUsize::new(2).unwrap())
             .get();
 
+        // Use default extension for recursive loading.
+        let extension = if Path::new(&path).is_dir() {
+            DEFAULT_PARQUET_EXTENSION
+        } else {
+            ""
+        };
+
         let file_format = ParquetFormat::new();
         let listing_options = ListingOptions::new(Arc::new(file_format))
-            .with_file_extension(DEFAULT_PARQUET_EXTENSION)
+            .with_file_extension(extension)
             .with_target_partitions(num_cpus);
 
         let resolved_schema =


### PR DESCRIPTION
Loading functions like `json`, `csv`, and `parquet` would skip loading data for files ending with an extension different then the file type, for example `json` would ignore a file with a txt extension even if that file contains correct json data, with this change we only use a default extension when doing a recursive load from a folder.