### PR TITLE
Add back ticks to completions for columns with non identifier names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes to the `dply` crate are documented in this file.
 ## 0.2.1 - Unreleased
 ### 🐛 Fixed
 * Allow user to override file extensions when loading data.
+### ⭐ Added
+* Add backticks to completions for columns names that are not alphanumeric.
+
 
 ## 0.2.0 - 2023-08-14
 ### 🔧 Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ nom = "7"
 num-traits = "0.2.15"
 parking_lot = "0.12.1"
 reedline = "0.23"
-regex = "1.8.4"
+regex = "1.9.4"
 thiserror = "1.0"
 tokio = { version = "1.29.1", features = ["rt-multi-thread", "macros", "sync"] }
 


### PR DESCRIPTION
There are columns whose names contain space or characters like dash, question marks, etc.