### PR TITLE
Fix glimpse panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,97 +1,136 @@
 # dply changelog
+
 Changes to the `dply` crate are documented in this file.
 
 ## 0.3.1 - Unreleased
-### 🔧 Changed
-* Update to Polars 0.39
 
+### 🔧 Changed
+
+- Update to Polars 0.39
+- Fix glimpse panic [#66](https://github.com/vincev/dply-rs/issues/66)
 
 ## 0.3.0 - 2024-03-04
+
 ### ⭐ Added
-* Add support for struct unnesting into columns (see [unnest_struct](https://github.com/vincev/dply-rs/blob/0626169d97b346b0a0eea6a9843bcda98ddfa1d1/tests/functions/unnest.rs#L122) test).
+
+- Add support for struct unnesting into columns (see [unnest_struct](https://github.com/vincev/dply-rs/blob/0626169d97b346b0a0eea6a9843bcda98ddfa1d1/tests/functions/unnest.rs#L122) test).
 
 ## 0.2.1 - 2023-10-12
-### 🐛 Fixed
-* Allow user to override file extensions when loading data.
-### 🔧 Changed
-* `mutate`: Rename `dt` to `ymd_hms` following the lubridate R package.
-### ⭐ Added
-* Add backticks to completions for columns names that are not alphanumeric.
-* `mutate`: Add `dnanos`, `dmicros`, `dmillis`, and `dsecs` to convert numbers to duration.
-* `mutate`: Add `nanos`, `micros`, `millis`, and `secs` to convert duration to numbers.
 
+### 🐛 Fixed
+
+- Allow user to override file extensions when loading data.
+
+### 🔧 Changed
+
+- `mutate`: Rename `dt` to `ymd_hms` following the lubridate R package.
+
+### ⭐ Added
+
+- Add backticks to completions for columns names that are not alphanumeric.
+- `mutate`: Add `dnanos`, `dmicros`, `dmillis`, and `dsecs` to convert numbers to duration.
+- `mutate`: Add `nanos`, `micros`, `millis`, and `secs` to convert duration to numbers.
 
 ## 0.2.0 - 2023-08-14
+
 ### 🔧 Changed
-* Use DataFusion as query engine.
-* `parquet`: Speedup parquet writing for multiple partitions (about 40% increase).
-* `parquet`: A folder path reads all parquet files in the folder.
-* `parquet`: write now uses compression to reduce file size.
-* `mutate`: Make `len` function to work on strings.
-* Improve display precision for microsecond and nanosecond timestamps.
+
+- Use DataFusion as query engine.
+- `parquet`: Speedup parquet writing for multiple partitions (about 40% increase).
+- `parquet`: A folder path reads all parquet files in the folder.
+- `parquet`: write now uses compression to reduce file size.
+- `mutate`: Make `len` function to work on strings.
+- Improve display precision for microsecond and nanosecond timestamps.
+
 ### ⭐ Added
-* Added `json` function to read and write NdJSON files.
-* Added `config` function to set display options (number of columns, and column and table width).
-* `anti_join`: Added `anti_join` to select rows not found in the orther data frame.
-* `mutate`: Add `field` function to extract fields from a JSON/struct objects.
-* `mutate`: Add `row` function that returns the row number.
-* Show execution time on dataframe header.
+
+- Added `json` function to read and write NdJSON files.
+- Added `config` function to set display options (number of columns, and column and table width).
+- `anti_join`: Added `anti_join` to select rows not found in the orther data frame.
+- `mutate`: Add `field` function to extract fields from a JSON/struct objects.
+- `mutate`: Add `row` function that returns the row number.
+- Show execution time on dataframe header.
 
 ## 0.1.9 - 2023-06-28
+
 ### 🔧 Changed
-* Improve glimpse formatting.
+
+- Improve glimpse formatting.
+
 ### 🐛 Fixed
-* repl: Fix completions for absolute and tilde paths.
-* repl: Keep all completion columns for big dataframes.
+
+- repl: Fix completions for absolute and tilde paths.
+- repl: Keep all completion columns for big dataframes.
 
 ## 0.1.8 - 2023-06-19
+
 ### ⭐ Added
-* repl: Add parenthesis to functions completions. (See Issue #27)
-* repl: Completions starting with a `.` show only columns and variables.
-* repl: Show completions for most recently used columns.
+
+- repl: Add parenthesis to functions completions. (See Issue #27)
+- repl: Completions starting with a `.` show only columns and variables.
+- repl: Show completions for most recently used columns.
 
 ## 0.1.7 - 2023-06-11
+
 ### ⭐ Added
-* Add REPL fuzzy matching.
+
+- Add REPL fuzzy matching.
+
 ### 🐛 Fixed
-* Prevent out of bound REPL panic on completion.
-* Clear evaluation context before REPL pipeline evaluation.
+
+- Prevent out of bound REPL panic on completion.
+- Clear evaluation context before REPL pipeline evaluation.
 
 ## 0.1.6 - 2023-06-08
+
 ### ⭐ Added
-* Add `reedline` REPL.
+
+- Add `reedline` REPL.
 
 ## 0.1.5 - 2023-05-29
+
 ### ⭐ Added
-* Add `inner_join`, `left_join`, `cross_join`, and `outer_join`.
-* Add semicolon pipeline separator.
-* Enable `unnest` to work on struct columns.
-* `summarize`: Add `list` function for creating list columns from grouped data.
+
+- Add `inner_join`, `left_join`, `cross_join`, and `outer_join`.
+- Add semicolon pipeline separator.
+- Enable `unnest` to work on struct columns.
+- `summarize`: Add `list` function for creating list columns from grouped data.
 
 ### 🔧 Changed
-* Update to Polars 0.30
+
+- Update to Polars 0.30
 
 ## 0.1.4 - 2023-05-16
+
 ### ⭐ Added
-* Add `unnest` function for list columns.
+
+- Add `unnest` function for list columns.
 
 ## 0.1.3 - 2023-05-15
+
 ### ⭐ Added
-* `filter`: Add `contains` predicate for string and list columns.
-* `filter`: Add `is_null` predicate.
-* `mutate`: Add `len` function for list columns.
+
+- `filter`: Add `contains` predicate for string and list columns.
+- `filter`: Add `is_null` predicate.
+- `mutate`: Add `len` function for list columns.
 
 ### 🔧 Changed
-* Update to Polars 0.29
-* `summarize`: Now works on ungrouped data.
+
+- Update to Polars 0.29
+- `summarize`: Now works on ungrouped data.
 
 ## 0.1.2 - 2023-05-09
+
 ### ⭐ Added
-* Add support for quoting column names (ex. `last name`).
+
+- Add support for quoting column names (ex. `last name`).
 
 ## 0.1.1 - 2023-05-08
+
 ### 🔧 changed
-* Simplify README.md created docs folder.
+
+- Simplify README.md created docs folder.
 
 ## 0.1.0 - 2023-05-08
-* Initial release
+
+- Initial release

--- a/src/engine/fmt.rs
+++ b/src/engine/fmt.rs
@@ -89,8 +89,9 @@ pub fn glimpse(w: &mut dyn Write, df: LazyFrame) -> Result<()> {
         row.add_cell(format!("{}", col.dtype()).into());
 
         let mut values = Vec::with_capacity(10);
-        for value in col.iter() {
-            values.push(format!("{}", value));
+        for idx in 0..col.len() {
+            let value = col.str_value(idx).unwrap_or_default();
+            values.push(value.into_owned());
         }
 
         row.add_cell(values.join(", ").into());

--- a/tests/functions/glimpse.rs
+++ b/tests/functions/glimpse.rs
@@ -22,11 +22,11 @@ fn glimpse_parquet() -> Result<()> {
             │ tpep_dropoff_datetime ┆ datetime[ns] ┆ 2022-11-22 19:45:53, 2022-11-27...      │
             │ passenger_count       ┆ i64          ┆ 1, 2, 1, 1, 3, 1, 2, 1, 1, 2, 2, 1, ... │
             │ trip_distance         ┆ f64          ┆ 3.14, 1.06, 2.36, 5.2, 0.0, 2.39, 1.... │
-            │ rate_code             ┆ str          ┆ "Standard", "Standard", "Standard",...  │
-            │ store_and_fwd_flag    ┆ str          ┆ "N", "N", "N", "N", "N", "N", "N", "... │
+            │ rate_code             ┆ str          ┆ Standard, Standard, Standard, Standa... │
+            │ store_and_fwd_flag    ┆ str          ┆ N, N, N, N, N, N, N, N, N, N, N, N, ... │
             │ PULocationID          ┆ i64          ┆ 234, 48, 142, 79, 237, 137, 107, 229... │
             │ DOLocationID          ┆ i64          ┆ 141, 142, 236, 75, 230, 140, 162, 16... │
-            │ payment_type          ┆ str          ┆ "Credit card", "Cash", "Credit card"... │
+            │ payment_type          ┆ str          ┆ Credit card, Cash, Credit card, Cred... │
             │ fare_amount           ┆ f64          ┆ 14.5, 6.5, 11.5, 18.0, 12.5, 19.0, 8... │
             │ extra                 ┆ f64          ┆ 1.0, 0.0, 0.0, 0.5, 3.0, 0.0, 0.0, 0... │
             │ mta_tax               ┆ f64          ┆ 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0... │
@@ -57,15 +57,15 @@ fn glimpse_csv() -> Result<()> {
             │ Cols: 19              ┆        ┆                                               │
             ╞═══════════════════════╪════════╪═══════════════════════════════════════════════╡
             │ VendorID              ┆ i64    ┆ 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1, 1, 2, ... │
-            │ tpep_pickup_datetime  ┆ str    ┆ "2022-11-22T19:27:01.000000000",...           │
-            │ tpep_dropoff_datetime ┆ str    ┆ "2022-11-22T19:45:53.000000000",...           │
+            │ tpep_pickup_datetime  ┆ str    ┆ 2022-11-22T19:27:01.000000000,...             │
+            │ tpep_dropoff_datetime ┆ str    ┆ 2022-11-22T19:45:53.000000000,...             │
             │ passenger_count       ┆ i64    ┆ 1, 2, 1, 1, 3, 1, 2, 1, 1, 2, 2, 1, 1, 1, ... │
             │ trip_distance         ┆ f64    ┆ 3.14, 1.06, 2.36, 5.2, 0.0, 2.39, 1.52, 0.... │
-            │ rate_code             ┆ str    ┆ "Standard", "Standard", "Standard",...        │
-            │ store_and_fwd_flag    ┆ str    ┆ "N", "N", "N", "N", "N", "N", "N", "N", "N... │
+            │ rate_code             ┆ str    ┆ Standard, Standard, Standard, Standard,...    │
+            │ store_and_fwd_flag    ┆ str    ┆ N, N, N, N, N, N, N, N, N, N, N, N, N, N, ... │
             │ PULocationID          ┆ i64    ┆ 234, 48, 142, 79, 237, 137, 107, 229, 162,... │
             │ DOLocationID          ┆ i64    ┆ 141, 142, 236, 75, 230, 140, 162, 161, 186... │
-            │ payment_type          ┆ str    ┆ "Credit card", "Cash", "Credit card", "Cre... │
+            │ payment_type          ┆ str    ┆ Credit card, Cash, Credit card, Credit car... │
             │ fare_amount           ┆ f64    ┆ 14.5, 6.5, 11.5, 18.0, 12.5, 19.0, 8.5, 6.... │
             │ extra                 ┆ f64    ┆ 1.0, 0.0, 0.0, 0.5, 3.0, 0.0, 0.0, 0.0, 1.... │
             │ mta_tax               ┆ f64    ┆ 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.... │


### PR DESCRIPTION
Fix glimpse panic #66:

```shell
dply  -c 'csv("./Data7602DescendingYearOrder.csv") | glimpse()' 
┌─────────────────┬────────┬───────────────────────────────────────────────────┐
│ Rows: 5,429,252 ┆ Type   ┆ Values                                            │
│ Cols: 5         ┆        ┆                                                   │
╞═════════════════╪════════╪═══════════════════════════════════════════════════╡
│ anzsic06        ┆ str    ┆ A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A... │
│ Area            ┆ str    ┆ A100100, A100200, A100300, A100400, A100500,...   │
│ year            ┆ i64    ┆ 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000... │
│ geo_count       ┆ i64    ┆ 96, 198, 42, 66, 63, 21, 45, 36, 78, 42, 39, 1... │
│ ec_count        ┆ i64    ┆ 130, 110, 25, 40, 40, 12, 60, 60, 18, 9, 35, 2... │
└─────────────────┴────────┴───────────────────────────────────────────────────┘
```